### PR TITLE
Fix(mobile): Adjust avatar positions and verify background styles

### DIFF
--- a/src/assets/footer.scss
+++ b/src/assets/footer.scss
@@ -2,6 +2,7 @@
     background-color: #1A1A1A;
     position: sticky;
     bottom: 0;
+    z-index: 100;
     height: 50px;
     width: 90%;
     left: 5%;

--- a/src/assets/footer.scss
+++ b/src/assets/footer.scss
@@ -1,4 +1,5 @@
 .footer {
+    background-color: #1A1A1A;
     position: sticky;
     bottom: 0;
     height: 50px;

--- a/src/assets/investors-screen.scss
+++ b/src/assets/investors-screen.scss
@@ -99,7 +99,7 @@
         @media (max-width: 768px) {
             padding-inline: 0!important;
             padding-bottom: 60px; /* Adicionado para separar do footer */
-            padding-top: 80px; /* Adiciona espaço no topo para mobile */
+            padding-top: 20px; /* Adiciona espaço no topo para mobile */
             height: auto; /* Permite altura automática */
             min-height: 100vh; /* Garante altura mínima */
         }

--- a/src/assets/investors-screen.scss
+++ b/src/assets/investors-screen.scss
@@ -6,6 +6,7 @@
     justify-content: center;
     align-items: center;
     background: url("/spaceBG.png") no-repeat center/cover;
+    background-color: #000000;
     animation: fadeIn 0.8s ease-out;
 
     @media (max-width: 768px) {

--- a/src/assets/jobs-screen.scss
+++ b/src/assets/jobs-screen.scss
@@ -4,6 +4,7 @@
     width: 100%;
     height: 100%;
     background: url("/spaceBG.png") no-repeat center/cover;
+    background-color: #000000;
     animation: fadeIn 0.8s ease-out;
 
     @media (max-width: 768px) {

--- a/src/assets/team-screen.scss
+++ b/src/assets/team-screen.scss
@@ -99,7 +99,7 @@
         @media (max-width: 768px) {
             padding-inline: 0!important;
             padding-bottom: 60px; /* Adicionado para separar do footer */
-            padding-top: 80px; /* Adiciona espaço no topo para mobile */
+            padding-top: 20px; /* Adiciona espaço no topo para mobile */
             height: auto; /* Permite altura automática */
             min-height: 100vh; /* Garante altura mínima */
         }

--- a/src/assets/team-screen.scss
+++ b/src/assets/team-screen.scss
@@ -6,6 +6,7 @@
     justify-content: center;
     align-items: center;
     background: url("/spaceBG.png") no-repeat center/cover;
+    background-color: #000000;
     animation: fadeIn 0.8s ease-out;
 
     @media (max-width: 768px) {


### PR DESCRIPTION
- Verified that mobile background images and scrolling behavior for homepage and other sections (Jobs, Investors, Team) are correctly implemented as per requirements.
- Reduced top padding for avatar containers on Team and Investors pages from 80px to 20px in mobile view. This makes the first avatar in these sections appear higher on the screen, addressing the issue of them seeming to start "in the middle".