### PR TITLE
Fix: Ensure screen backgrounds cover footer area on desktop scroll

### DIFF
--- a/src/assets/footer.scss
+++ b/src/assets/footer.scss
@@ -1,8 +1,6 @@
 .footer {
-    background-color: #1A1A1A;
     position: sticky;
     bottom: 0;
-    z-index: 100;
     height: 50px;
     width: 90%;
     left: 5%;

--- a/src/assets/investors-screen.scss
+++ b/src/assets/investors-screen.scss
@@ -5,8 +5,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    background: url("/spaceBG.png") no-repeat center/cover;
-    background-color: #000000;
+    background: url("/spaceBG.png") no-repeat center/cover fixed;
     animation: fadeIn 0.8s ease-out;
 
     @media (max-width: 768px) {

--- a/src/assets/jobs-screen.scss
+++ b/src/assets/jobs-screen.scss
@@ -3,8 +3,7 @@
     position: relative;
     width: 100%;
     height: 100%;
-    background: url("/spaceBG.png") no-repeat center/cover;
-    background-color: #000000;
+    background: url("/spaceBG.png") no-repeat center/cover fixed;
     animation: fadeIn 0.8s ease-out;
 
     @media (max-width: 768px) {

--- a/src/assets/team-screen.scss
+++ b/src/assets/team-screen.scss
@@ -5,8 +5,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    background: url("/spaceBG.png") no-repeat center/cover;
-    background-color: #000000;
+    background: url("/spaceBG.png") no-repeat center/cover fixed;
     animation: fadeIn 0.8s ease-out;
 
     @media (max-width: 768px) {


### PR DESCRIPTION
I changed the 'background-attachment' property to 'fixed' for the desktop versions of the Jobs, Investors, and Team pages. This prevents an issue where the screen's background image could scroll out from behind the transparent footer, revealing the default white body background and creating a "white rectangle" artifact.

With fixed attachment, the screen backgrounds now consistently cover the entire viewport area, providing a stable backdrop for the footer.

This commit also effectively reverts several previous attempts to fix this issue (e.g., adding opaque backgrounds to the footer or screens, changing body background) which were not successful or introduced other visual problems. The footer remains transparent as originally designed.